### PR TITLE
Display all Apache logs in container output for easier debugging.

### DIFF
--- a/apache-foreground
+++ b/apache-foreground
@@ -9,5 +9,5 @@ sudo -u www-data ./framework/sake dev/build
 echo "Starting apache..."
 apache2ctl start
 
-echo "Showing access.log..."
-tail -f /var/log/apache2/access.log
+echo "Showing logs..."
+tail -f /var/log/apache2/*.log


### PR DESCRIPTION
This is a minor change to output all logs from the `/var/log/apache` directory, which primarily means errors will be output in the console (instead of needing to access the box and less / tail the error log independently).