### PR TITLE
NO_DB and NO_DEV_BUILD flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ a command. In this example, we have mapped port 3000 to the HTTP port of the con
     build_dir=`pwd`
     docker run -dP -p 3000:80 -v $build_dir:/var/www sminnee/silverstripe-lamp
 
+If you intend to use a separate container for your database, or don't require `dev/build` to be run,
+you can pass some environment variables to turn those features off:
+
+	build_dir=`pwd`
+	docker run -dP -p 3000:80 -e NO_DB=1 NO_DEV_BUILD=1 -v $build_dir:/var/www sminnee/silverstripe-lamp
+
 **Note:** This is for development purposes only; the root database user has no password.
 
 Development

--- a/apache-foreground
+++ b/apache-foreground
@@ -1,12 +1,23 @@
 #!/bin/bash  
-echo "Starting MySQL..."
-/etc/init.d/mysql start
 
-echo "Running dev/build..."
-cd /var/www
-sudo -u www-data ./framework/sake dev/build
+# Only start database if NO_DB is not passed
+if [ -z ${NO_DB+x} ]; then
+	echo "Starting MySQL..."
+	/etc/init.d/mysql start
+else
+	echo "Running without DB..."
+fi
 
-echo "Starting apache..."
+# Only start database if NO_DEV_BUILD is not passed
+if [ -z ${NO_DEV_BUILD+x} ]; then
+	echo "Running dev/build..."
+	cd /var/www
+	sudo -u www-data ./framework/sake dev/build
+else
+	echo "Running without dev/build..."
+fi
+
+echo "Starting Apache..."
 apache2ctl start
 
 echo "Showing access.log..."


### PR DESCRIPTION
In some development environments, a separate container may be used for MySQL or MySQL may not be required at all. In a similar vein, the default `dev/build` call may be unnecessary if the database has already been set up or isn't being used.

With this PR, I've introduced two environment variables to address these situations: `NO_DB` and `NO_DEV_BUILD`. If passed when starting the container, they will disable the relevant part of the default `apache-foreground` script.

A minor README change to document this behaviour is included.